### PR TITLE
Update WindowsTargetPlatformVersion

### DIFF
--- a/out/Exporters/VisualStudioExporter.js
+++ b/out/Exporters/VisualStudioExporter.js
@@ -473,13 +473,13 @@ class VisualStudioExporter extends Exporter_1.Exporter {
             this.p('<AppContainerApplication>true</AppContainerApplication>', 2);
             this.p('<ApplicationType>Windows Store</ApplicationType>', 2);
             this.p('<ApplicationTypeRevision>8.2</ApplicationTypeRevision>', 2);
-            this.p('<WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>', 2);
-            this.p('<WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>', 2);
+            this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
+            this.p('<WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>', 2);
             this.p('<ApplicationTypeRevision>10.0</ApplicationTypeRevision>', 2);
             this.p('<EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>', 2);
         }
         else if (Options_1.Options.graphicsApi === GraphicsApi_1.GraphicsApi.Direct3D12) {
-            this.p('<WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>', 2);
+            this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
         }
         this.p('</PropertyGroup>', 1);
         this.p('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />', 1);

--- a/out/Project.js
+++ b/out/Project.js
@@ -4,7 +4,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
 const fs = require("fs-extra");

--- a/out/main.js
+++ b/out/main.js
@@ -4,7 +4,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
 const child_process = require("child_process");

--- a/src/Exporters/VisualStudioExporter.ts
+++ b/src/Exporters/VisualStudioExporter.ts
@@ -481,13 +481,13 @@ export class VisualStudioExporter extends Exporter {
 			this.p('<AppContainerApplication>true</AppContainerApplication>', 2);
 			this.p('<ApplicationType>Windows Store</ApplicationType>', 2);
 			this.p('<ApplicationTypeRevision>8.2</ApplicationTypeRevision>', 2);
-			this.p('<WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>', 2);
-			this.p('<WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>', 2);
+			this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
+			this.p('<WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>', 2);
 			this.p('<ApplicationTypeRevision>10.0</ApplicationTypeRevision>', 2);
 			this.p('<EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>', 2);
 		}
 		else if (Options.graphicsApi === GraphicsApi.Direct3D12) {
-			this.p('<WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>', 2);
+			this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
 		}
 		this.p('</PropertyGroup>', 1);
 		this.p('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />', 1);


### PR DESCRIPTION
Gets rid of need to 'Retarget solution' after opening project when using latest Visual Studio 2015 installation.