### PR TITLE
Update WindowsTargetPlatformVersion

### DIFF
--- a/out/Exporters/VisualStudioExporter.js
+++ b/out/Exporters/VisualStudioExporter.js
@@ -484,7 +484,7 @@ class VisualStudioExporter extends Exporter_1.Exporter {
         // p("<RootNamespace>" + project.Name + "</RootNamespace>", 2);
         if (Options_1.Options.visualStudioVersion === VisualStudioVersion_1.VisualStudioVersion.VS2017) {
             this.p('<VCProjectVersion>15.0</VCProjectVersion>');
-            this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>');
+            this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>');
         }
         if (platform === Platform_1.Platform.WindowsApp) {
             this.p('<DefaultLanguage>en-US</DefaultLanguage>', 2);
@@ -492,13 +492,13 @@ class VisualStudioExporter extends Exporter_1.Exporter {
             this.p('<AppContainerApplication>true</AppContainerApplication>', 2);
             this.p('<ApplicationType>Windows Store</ApplicationType>', 2);
             this.p('<ApplicationTypeRevision>8.2</ApplicationTypeRevision>', 2);
-            this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
-            this.p('<WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>', 2);
+            this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>', 2);
+            this.p('<WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>', 2);
             this.p('<ApplicationTypeRevision>10.0</ApplicationTypeRevision>', 2);
             this.p('<EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>', 2);
         }
         else if (Options_1.Options.graphicsApi === GraphicsApi_1.GraphicsApi.Direct3D12) {
-            this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
+            this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>', 2);
         }
         this.p('</PropertyGroup>', 1);
         this.p('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />', 1);

--- a/src/Exporters/VisualStudioExporter.ts
+++ b/src/Exporters/VisualStudioExporter.ts
@@ -490,7 +490,7 @@ export class VisualStudioExporter extends Exporter {
 		// p("<RootNamespace>" + project.Name + "</RootNamespace>", 2);
 		if (Options.visualStudioVersion === VisualStudioVersion.VS2017) {
 			this.p('<VCProjectVersion>15.0</VCProjectVersion>');
-			this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>');
+			this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>');
 		}
 		if (platform === Platform.WindowsApp) {
 			this.p('<DefaultLanguage>en-US</DefaultLanguage>', 2);
@@ -498,13 +498,13 @@ export class VisualStudioExporter extends Exporter {
 			this.p('<AppContainerApplication>true</AppContainerApplication>', 2);
 			this.p('<ApplicationType>Windows Store</ApplicationType>', 2);
 			this.p('<ApplicationTypeRevision>8.2</ApplicationTypeRevision>', 2);
-			this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
-			this.p('<WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>', 2);
+			this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>', 2);
+			this.p('<WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>', 2);
 			this.p('<ApplicationTypeRevision>10.0</ApplicationTypeRevision>', 2);
 			this.p('<EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>', 2);
 		}
 		else if (Options.graphicsApi === GraphicsApi.Direct3D12) {
-			this.p('<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>', 2);
+			this.p('<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>', 2);
 		}
 		this.p('</PropertyGroup>', 1);
 		this.p('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />', 1);


### PR DESCRIPTION
Gets rid of need to 'Retarget solution' after opening project when using latest Visual Studio 2017 installation.