### PR TITLE
fixing 'relocation overflow in R_ARM_THM_CALL'

### DIFF
--- a/Data/android/app/build.gradle
+++ b/Data/android/app/build.gradle
@@ -13,6 +13,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "{cppflags}"
+                arguments '-DANDROID_ARM_MODE=arm'
             }
         }
     }


### PR DESCRIPTION
For some reason I get 'relocation overflow in R_ARM_THM_CALL' whilst building for android device.
Need to enable '-DANDROID_ARM_MODE=arm' in build.gradle in order to build.

As described here: https://stackoverflow.com/questions/45845787/cant-force-arm-mode-in-android-studio

