### PR TITLE
cppflags target option for android

### DIFF
--- a/out/Exporters/AndroidExporter.js
+++ b/out/Exporters/AndroidExporter.js
@@ -18,6 +18,7 @@ class AndroidExporter extends Exporter_1.Exporter {
             permissions: new Array(),
             disableStickyImmersiveMode: false
         };
+        let cppflags = '';
         if (project.targetOptions != null && project.targetOptions.android != null) {
             let userOptions = project.targetOptions.android;
             if (userOptions.package != null)
@@ -28,6 +29,8 @@ class AndroidExporter extends Exporter_1.Exporter {
                 targetOptions.permissions = userOptions.permissions;
             if (userOptions.disableStickyImmersiveMode != null)
                 targetOptions.disableStickyImmersiveMode = userOptions.disableStickyImmersiveMode;
+            if (userOptions.cppflags != null)
+                cppflags += userOptions.cppflags;
         }
         const indir = path.join(__dirname, '..', '..', 'Data', 'android');
         const outdir = path.join(to.toString(), safename);
@@ -40,7 +43,7 @@ class AndroidExporter extends Exporter_1.Exporter {
         fs.copySync(path.join(indir, 'app', 'gitignore'), path.join(outdir, 'app', '.gitignore'));
         let gradle = fs.readFileSync(path.join(indir, 'app', 'build.gradle'), { encoding: 'utf8' });
         gradle = gradle.replace(/{package}/g, targetOptions.package);
-        let cppflags = '-frtti -fexceptions';
+        cppflags = '-frtti -fexceptions ' + cppflags;
         if (project.cpp11) {
             cppflags = '-std=c++11 ' + cppflags;
         }

--- a/src/Exporters/AndroidExporter.ts
+++ b/src/Exporters/AndroidExporter.ts
@@ -22,12 +22,16 @@ export class AndroidExporter extends Exporter {
 			permissions: new Array<string>(),
 			disableStickyImmersiveMode: false
 		};
+
+		let cppflags = '';
+
 		if (project.targetOptions != null && project.targetOptions.android != null) {
 			let userOptions = project.targetOptions.android;
 			if (userOptions.package != null) targetOptions.package = userOptions.package;
 			if (userOptions.screenOrientation != null) targetOptions.screenOrientation = userOptions.screenOrientation;
 			if (userOptions.permissions != null) targetOptions.permissions = userOptions.permissions;
 			if (userOptions.disableStickyImmersiveMode != null) targetOptions.disableStickyImmersiveMode = userOptions.disableStickyImmersiveMode;
+			if (userOptions.cppflags != null) cppflags += userOptions.cppflags;
 		}
 
 		const indir = path.join(__dirname, '..', '..', 'Data', 'android');
@@ -45,7 +49,7 @@ export class AndroidExporter extends Exporter {
 		let gradle = fs.readFileSync(path.join(indir, 'app', 'build.gradle'), {encoding: 'utf8'});
 		gradle = gradle.replace(/{package}/g, targetOptions.package);
 
-		let cppflags = '-frtti -fexceptions';
+		cppflags = '-frtti -fexceptions ' + cppflags;
 		if (project.cpp11) {
 			cppflags = '-std=c++11 ' + cppflags;
 		}


### PR DESCRIPTION
I think it would be useful to pass additional cpp flags from khafile. For example I would like to disable cpp warnings when building android-native:
```js
//khafile.js
project.targetOptions.android_native.cppflags = '-w';
```