### PR TITLE
Fix disregarding debug flag on file copy on Windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -335,7 +335,7 @@ function compileProject(make: child_process.ChildProcess, project: Project, solu
 					fs.copySync(path.join(path.join(options.to.toString(), options.buildPath), solutionName), path.join(options.from.toString(), project.getDebugDir(), solutionName), { overwrite: true });
 				}
 				else if ((options.customTarget && options.customTarget.baseTarget === Platform.Windows) || options.target === Platform.Windows) {
-					fs.copySync(path.join(options.to.toString(), 'Release', solutionName + '.exe'), path.join(options.from.toString(), project.getDebugDir(), solutionName + '.exe'), { overwrite: true });
+					fs.copySync(path.join(options.to.toString(), options.debug ? 'Debug' : 'Release', solutionName + '.exe'), path.join(options.from.toString(), project.getDebugDir(), solutionName + '.exe'), { overwrite: true });
 				}
 				if (options.run) {
 					if ((options.customTarget && options.customTarget.baseTarget === Platform.OSX) || options.target === Platform.OSX) {


### PR DESCRIPTION
`--compile --debug` no longer crash after compilation with trying to copy release executable (or copy wrong executable in general)