### PR TITLE
Fix project.addCppFlags for Android

### DIFF
--- a/Data/android/app/build.gradle
+++ b/Data/android/app/build.gradle
@@ -12,6 +12,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "{cppflags}"
+                cFlags "{cflags}"
                 arguments '-DANDROID_ARM_MODE=arm'
             }
         }

--- a/out/Exporters/AndroidExporter.js
+++ b/out/Exporters/AndroidExporter.js
@@ -18,7 +18,12 @@ class AndroidExporter extends Exporter_1.Exporter {
             permissions: new Array(),
             disableStickyImmersiveMode: false
         };
+        let cflags = '';
+        for (let flag of project.cFlags)
+            cflags += flag + ' ';
         let cppflags = '';
+        for (let flag of project.cppFlags)
+            cppflags += flag + ' ';
         if (project.targetOptions != null && project.targetOptions.android != null) {
             let userOptions = project.targetOptions.android;
             if (userOptions.package != null)
@@ -29,8 +34,6 @@ class AndroidExporter extends Exporter_1.Exporter {
                 targetOptions.permissions = userOptions.permissions;
             if (userOptions.disableStickyImmersiveMode != null)
                 targetOptions.disableStickyImmersiveMode = userOptions.disableStickyImmersiveMode;
-            if (userOptions.cppflags != null)
-                cppflags += userOptions.cppflags;
         }
         const indir = path.join(__dirname, '..', '..', 'Data', 'android');
         const outdir = path.join(to.toString(), safename);
@@ -43,6 +46,7 @@ class AndroidExporter extends Exporter_1.Exporter {
         fs.copySync(path.join(indir, 'app', 'gitignore'), path.join(outdir, 'app', '.gitignore'));
         let gradle = fs.readFileSync(path.join(indir, 'app', 'build.gradle'), { encoding: 'utf8' });
         gradle = gradle.replace(/{package}/g, targetOptions.package);
+        gradle = gradle.replace(/{cflags}/g, cflags);
         cppflags = '-frtti -fexceptions ' + cppflags;
         if (project.cpp11) {
             cppflags = '-std=c++11 ' + cppflags;

--- a/out/koremake.js
+++ b/out/koremake.js
@@ -215,7 +215,7 @@ for (let i = 2; i < args.length; ++i) {
         }
     }
     else {
-        parsedOptions.target = arg;
+        parsedOptions.target = arg.toLowerCase();
     }
 }
 if (parsedOptions.run) {

--- a/src/Exporters/AndroidExporter.ts
+++ b/src/Exporters/AndroidExporter.ts
@@ -23,7 +23,12 @@ export class AndroidExporter extends Exporter {
 			disableStickyImmersiveMode: false
 		};
 
+		let cflags = '';
+		for (let flag of project.cFlags)
+			cflags += flag + ' ';
 		let cppflags = '';
+		for (let flag of project.cppFlags)
+			cppflags += flag + ' ';
 
 		if (project.targetOptions != null && project.targetOptions.android != null) {
 			let userOptions = project.targetOptions.android;
@@ -31,7 +36,6 @@ export class AndroidExporter extends Exporter {
 			if (userOptions.screenOrientation != null) targetOptions.screenOrientation = userOptions.screenOrientation;
 			if (userOptions.permissions != null) targetOptions.permissions = userOptions.permissions;
 			if (userOptions.disableStickyImmersiveMode != null) targetOptions.disableStickyImmersiveMode = userOptions.disableStickyImmersiveMode;
-			if (userOptions.cppflags != null) cppflags += userOptions.cppflags;
 		}
 
 		const indir = path.join(__dirname, '..', '..', 'Data', 'android');
@@ -48,6 +52,8 @@ export class AndroidExporter extends Exporter {
 
 		let gradle = fs.readFileSync(path.join(indir, 'app', 'build.gradle'), {encoding: 'utf8'});
 		gradle = gradle.replace(/{package}/g, targetOptions.package);
+
+		gradle = gradle.replace(/{cflags}/g, cflags);
 
 		cppflags = '-frtti -fexceptions ' + cppflags;
 		if (project.cpp11) {


### PR DESCRIPTION
Fixes the `project.addCppFlags` for me, unless I am missing something and it's really meant to be passed through `userOptions`.

Also works for `project.addCFlags`.