### PR TITLE
Bump ios deployment version to 8.0

### DIFF
--- a/out/Exporters/XCodeExporter.js
+++ b/out/Exporters/XCodeExporter.js
@@ -570,7 +570,7 @@ class XCodeExporter extends Exporter_1.Exporter {
         this.p('GCC_WARN_UNUSED_FUNCTION = YES;', 4);
         this.p('GCC_WARN_UNUSED_VARIABLE = YES;', 4);
         if (platform === Platform_1.Platform.iOS) {
-            this.p('IPHONEOS_DEPLOYMENT_TARGET = 7.0;', 4);
+            this.p('IPHONEOS_DEPLOYMENT_TARGET = 8.0;', 4);
         }
         else {
             if (Options_1.Options.graphicsApi === GraphicsApi_1.GraphicsApi.OpenGL) {
@@ -643,7 +643,7 @@ class XCodeExporter extends Exporter_1.Exporter {
         this.p('GCC_WARN_UNUSED_FUNCTION = YES;', 4);
         this.p('GCC_WARN_UNUSED_VARIABLE = YES;', 4);
         if (platform === Platform_1.Platform.iOS) {
-            this.p('IPHONEOS_DEPLOYMENT_TARGET = 7.0;', 4);
+            this.p('IPHONEOS_DEPLOYMENT_TARGET = 8.0;', 4);
         }
         else {
             if (Options_1.Options.graphicsApi === GraphicsApi_1.GraphicsApi.OpenGL) {

--- a/src/Exporters/XCodeExporter.ts
+++ b/src/Exporters/XCodeExporter.ts
@@ -603,7 +603,7 @@ export class XCodeExporter extends Exporter {
 		this.p('GCC_WARN_UNUSED_FUNCTION = YES;', 4);
 		this.p('GCC_WARN_UNUSED_VARIABLE = YES;', 4);
 		if (platform === Platform.iOS) {
-			this.p('IPHONEOS_DEPLOYMENT_TARGET = 7.0;', 4);
+			this.p('IPHONEOS_DEPLOYMENT_TARGET = 8.0;', 4);
 		}
 		else {
 			if (Options.graphicsApi === GraphicsApi.OpenGL) {
@@ -675,7 +675,7 @@ export class XCodeExporter extends Exporter {
 		this.p('GCC_WARN_UNUSED_FUNCTION = YES;', 4);
 		this.p('GCC_WARN_UNUSED_VARIABLE = YES;', 4);
 		if (platform === Platform.iOS) {
-			this.p('IPHONEOS_DEPLOYMENT_TARGET = 7.0;', 4);
+			this.p('IPHONEOS_DEPLOYMENT_TARGET = 8.0;', 4);
 		}
 		else {
 			if (Options.graphicsApi === GraphicsApi.OpenGL) {


### PR DESCRIPTION
HashLink needs 8.0 to compile, maybe we are fine to bump this?
ios 8 dates to 2014, latest is ios 12.