### PR TITLE
Fix Kode/Kha issue 959 (let khafile config. iOS app version)

### DIFF
--- a/out/Exporters/XCodeExporter.js
+++ b/out/Exporters/XCodeExporter.js
@@ -214,8 +214,8 @@ class XCodeExporter extends Exporter_1.Exporter {
         }
         let targetOptions = {
             bundle: 'tech.kode.$(PRODUCT_NAME:rfc1034identifier)',
-            // version: "1.0", // somehow the plist can't read the values for this
-            // build: "1", // somehow the plist can't read the values for this
+            version: "1.0",
+            build: "1",
             organizationName: 'the Kore Development Team',
             developmentTeam: ''
         };
@@ -223,8 +223,10 @@ class XCodeExporter extends Exporter_1.Exporter {
             let userOptions = project.targetOptions.ios;
             if (userOptions.bundle)
                 targetOptions.bundle = userOptions.bundle;
-            // if (userOptions.version) targetOptions.version = userOptions.version;
-            // if (userOptions.build) targetOptions.build = userOptions.build;
+            if (userOptions.version)
+                targetOptions.version = userOptions.version;
+            if (userOptions.build)
+                targetOptions.build = userOptions.build;
             if (userOptions.organizationName)
                 targetOptions.organizationName = userOptions.organizationName;
             if (userOptions.developmentTeam)
@@ -693,6 +695,7 @@ class XCodeExporter extends Exporter_1.Exporter {
             }
         }
         this.p(');', 4);
+        this.p('INFOPLIST_EXPAND_BUILD_SETTINGS = "YES";', 4);
         this.p('INFOPLIST_FILE = "' + path.resolve(from, plistname) + '";', 4);
         this.p('LD_RUNPATH_SEARCH_PATHS = (', 4);
         this.p('"$(inherited)",', 5);
@@ -720,8 +723,8 @@ class XCodeExporter extends Exporter_1.Exporter {
             this.p(');', 4);
         }
         this.p('PRODUCT_BUNDLE_IDENTIFIER = "' + targetOptions.bundle + '";', 4);
-        // this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
-        // this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
+        this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
+        this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
         this.p('PRODUCT_NAME = "$(TARGET_NAME)";', 4);
         this.p('};', 3);
         this.p('name = Debug;', 3);
@@ -747,6 +750,7 @@ class XCodeExporter extends Exporter_1.Exporter {
         for (let p of project.getIncludeDirs())
             this.p('"' + path.resolve(from, p).replace(/ /g, '\\\\ ') + '",', 5);
         this.p(');', 4);
+        this.p('INFOPLIST_EXPAND_BUILD_SETTINGS = "YES";', 4);
         this.p('INFOPLIST_FILE = "' + path.resolve(from, plistname) + '";', 4);
         if (platform === Platform_1.Platform.iOS) {
             this.p('LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";', 4);
@@ -769,8 +773,8 @@ class XCodeExporter extends Exporter_1.Exporter {
             this.p(');', 4);
         }
         this.p('PRODUCT_BUNDLE_IDENTIFIER = "' + targetOptions.bundle + '";', 4);
-        // this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
-        // this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
+        this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
+        this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
         this.p('PRODUCT_NAME = "$(TARGET_NAME)";', 4);
         this.p('};', 3);
         this.p('name = Release;', 3);

--- a/src/Exporters/XCodeExporter.ts
+++ b/src/Exporters/XCodeExporter.ts
@@ -260,16 +260,16 @@ export class XCodeExporter extends Exporter {
 
 		let targetOptions = {
 			bundle: 'tech.kode.$(PRODUCT_NAME:rfc1034identifier)',
-			// version: "1.0", // somehow the plist can't read the values for this
-			// build: "1", // somehow the plist can't read the values for this
+			version: "1.0",
+			build: "1",
 			organizationName: 'the Kore Development Team',
 			developmentTeam: ''
 		};
 		if (project.targetOptions && project.targetOptions.ios) {
 			let userOptions = project.targetOptions.ios;
 			if (userOptions.bundle) targetOptions.bundle = userOptions.bundle;
-			// if (userOptions.version) targetOptions.version = userOptions.version;
-			// if (userOptions.build) targetOptions.build = userOptions.build;
+			if (userOptions.version) targetOptions.version = userOptions.version;
+			if (userOptions.build) targetOptions.build = userOptions.build;
 			if (userOptions.organizationName) targetOptions.organizationName = userOptions.organizationName;
 			if (userOptions.developmentTeam) targetOptions.developmentTeam = userOptions.developmentTeam;
 		}
@@ -726,6 +726,7 @@ export class XCodeExporter extends Exporter {
 		}
 		this.p(');', 4);
 
+		this.p('INFOPLIST_EXPAND_BUILD_SETTINGS = "YES";', 4);
 		this.p('INFOPLIST_FILE = "' + path.resolve(from, plistname) + '";', 4);
 
 		this.p('LD_RUNPATH_SEARCH_PATHS = (', 4);
@@ -757,8 +758,8 @@ export class XCodeExporter extends Exporter {
 		}
 
 		this.p('PRODUCT_BUNDLE_IDENTIFIER = "' + targetOptions.bundle + '";', 4);
-		// this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
-		// this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
+		this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
+		this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
 		this.p('PRODUCT_NAME = "$(TARGET_NAME)";', 4);
 		this.p('};', 3);
 		this.p('name = Debug;', 3);
@@ -782,6 +783,7 @@ export class XCodeExporter extends Exporter {
 		this.p('"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",', 5);
 		for (let p of project.getIncludeDirs()) this.p('"' + path.resolve(from, p).replace(/ /g, '\\\\ ') + '",', 5);
 		this.p(');', 4);
+		this.p('INFOPLIST_EXPAND_BUILD_SETTINGS = "YES";', 4);
 		this.p('INFOPLIST_FILE = "' + path.resolve(from, plistname) + '";', 4);
 		if (platform === Platform.iOS) {
 			this.p('LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";', 4);
@@ -807,8 +809,8 @@ export class XCodeExporter extends Exporter {
 		}
 
 		this.p('PRODUCT_BUNDLE_IDENTIFIER = "' + targetOptions.bundle + '";', 4);
-		// this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
-		// this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
+		this.p('BUNDLE_VERSION = "' + targetOptions.version + '";', 4);
+		this.p('BUILD_VERSION = "' + targetOptions.build + '";', 4);
 		this.p('PRODUCT_NAME = "$(TARGET_NAME)";', 4);
 		this.p('};', 3);
 		this.p('name = Release;', 3);


### PR DESCRIPTION
This is the first half of the fix for Kode/Kha#959

The reason this wasn't working before, was because `INFOPLIST_EXPAND_BUILD_SETTINGS` was not configured.

> First, I set `INFOPLIST_EXPAND_BUILD_SETTINGS`, which allows me to define the app's version numbers in the `xcconfig` and have them automatically expanded in the `Info.plist` file

Quote from: https://lapcatsoftware.com/articles/xcconfig.html